### PR TITLE
feat(plugins) 新增百度地图插件, 百度UNIT技能分享码y6zae5

### DIFF
--- a/BaiduMap.py
+++ b/BaiduMap.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8-*-
+import json, jsonpath, re
+import requests
+from robot import config, logging
+from robot.sdk.AbstractPlugin import AbstractPlugin
+
+logger = logging.getLogger(__name__)
+CHINESE_NUMNERS={'一': 1, '二': 2, '两': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9}
+
+class Plugin(AbstractPlugin):
+
+    IS_IMMERSIVE = True  # 这是个沉浸式技能
+    SLUG = "BaiduMap"
+
+    def __init__(self, con):
+        super(Plugin, self).__init__(con)
+        self.parsed = None
+        self.routes = None
+
+    def hasNumbers(self, inputString):
+        return any(char.isnumeric() for char in inputString)
+
+    def request(self, url, params):
+        r = requests.get(url, params=params)
+        content = r.text
+        return json.loads(content)
+
+    def getLatLng(self, app_key, checkPlace):
+        #调出配置文件中的城市, 并找到出发点和目的地的经纬度
+        city = config.get('location', '深圳')
+        url_place = "http://api.map.baidu.com/place/v2/suggestion"
+        params_place = {
+            "query" : checkPlace,
+            "region" : city,
+            "city_limit" : "true",
+            "output" : "json",
+            "ak" : app_key,
+        }
+        res = self.request(url_place, params_place)
+        if res:
+            status = res["status"]
+            if status == 0:
+                if len(res['result']):
+                    self.place = res['result'][0]["name"]
+                    if not 'location' in res['result'][0]:
+                        return "%f,%f" % (res['result'][1]["location"]['lat'], res['result'][1]["location"]['lng'])
+                    else:
+                        return "%f,%f" % (res['result'][0]["location"]['lat'], res['result'][0]["location"]['lng'])
+                else:
+                    self.say(u"找不到{}的经纬度，对不起！".format(checkPlace))
+                    return
+            else:
+                logger.error(u"位置接口:" + res['message'])
+                return
+        else:
+            logger.error(u"位置接口调用失败")
+            return
+
+    def getRoutes(self, app_key, origin, destination):
+        url_direction = "http://api.map.baidu.com/direction/v2/transit"
+        params_direction = {
+            "origin" : origin,
+            "destination" : destination,
+            "ak" : app_key
+        }
+        res = self.request(url_direction, params_direction)
+        if res:
+            if res["status"] == 0:
+                if len(res['result']['routes']) > 0:
+                    taxiDuration = jsonpath.jsonpath(res, "$.[taxi].duration")[0]
+                    taxiFee = jsonpath.jsonpath(res, "$.[taxi].detail.[total_price]")
+                    result = jsonpath.jsonpath(res, "$..routes.*.duration")
+                    busroutes = jsonpath.jsonpath(res, '$..routes..steps')
+                    for route in range(len(busroutes)):
+                        instruc = ''
+                        for direction in range(len(busroutes[route])):
+                            if busroutes[route][direction][0]['vehicle_info']['type'] == 3 and instruc == '':
+                                instruc = re.sub(r'\([^)]*\)','',busroutes[route][direction][0]['instructions'])
+                            elif busroutes[route][direction][0]['vehicle_info']['type'] == 3:
+                                instruc = '{},接着{}'.format(instruc,re.sub(r'\([^)]*\)','',busroutes[route][direction][0]['instructions']))
+                        result[route] = '{},这条路线约耗时{}分钟'.format(instruc, round(result[route]/60))
+                    result.append('坐出租车的话需要{}分钟,白天大概要{}块，黑夜就要{}块'.format(round(taxiDuration/60), taxiFee[0], taxiFee[1]))
+                    return result
+                else:
+                    self.say(u"找不到导航路线，对不起！", cache=True)
+                    return
+            else:
+                logger.error(u"导航接口:" + res['message'])
+                return
+        else:
+            logger.error(u"导航接口调用失败")
+            return
+
+    def handle(self, text, parsed):
+        ##需在配置文件给百度地图的API
+        profile = config.get()
+        if self.SLUG not in profile or \
+           'app_key' not in profile[self.SLUG] or \
+           'origin' not in profile[self.SLUG]:
+            self.say(u"你得在配置文件调整一下呀，哼！", cache=True)
+            return
+
+        if any(word in text for word in ['退出', '结束', '可以不用了', '不用','谢谢','谢啦']):
+            self.clearImmersive()  # 去掉沉浸式
+            if not self.routes:
+                self.say('好的吧！不用就算了', cache=True)
+            else:
+                self.say('路上要小心哦！', cache=True)
+        elif self.hasNumbers(text) and any(word in text for word in ['第', '条']) and self.routes:
+            number = re.compile(r"(\d+\.?\d*|[一二三四五六七八九零十百千万亿]+|[0-9]+[,]*[0-9]+.[0-9]+)")
+            routeNumber = number.findall(text)[0]
+            routeNumber = CHINESE_NUMNERS[routeNumber]
+            if routeNumber < len(self.routes):
+                logger.info('{} 选了{}条'.format(text, routeNumber))
+                self.say('这是第{}条:{}, 还想要听别的路线吗？'.format(routeNumber, self.routes[routeNumber-1]))
+            else:
+                self.say('都说了只有{}条路线啦，哼！'.format(len(self.routes)-1), cache=True, onCompleted=lambda: self.con.doResponse(self.activeListen()))
+        elif any(word in text for word in ['打车', '出租车', '计程车']) and self.routes:
+            self.say('{}, 超贵的，对不对？还想听别的路线吗？'.format(self.routes[-1]))
+        else:
+            slots = self.nlu.getSlots(self.parsed, 'FIND_DIRECTION')  # 取出所有词槽
+            # 使用if and all来检查slots字典里是否有出发和目的地，多轮询问直到得到出发点和目的地
+            if not all(key in [item['name'] for item in slots] for key in {'user_start', 'user_to'}):
+                self.say("{}".format(self.nlu.getSay(self.parsed,'FIND_DIRECTION')), cache=True, onCompleted=lambda: self.con.doResponse(self.activeListen()))
+            else:
+                start_Point = self.nlu.getSlotWords(self.parsed, 'FIND_DIRECTION', 'user_start')
+                to_Point = self.nlu.getSlotWords(self.parsed, 'FIND_DIRECTION', 'user_to')
+
+                # 如果出发点是家里则调出配置文件的经纬度
+                app_key = profile[self.SLUG]['app_key']
+                destination = self.getLatLng(app_key, to_Point)
+                if any(word in start_Point for word in [u"我的家", u"家里", u"我家", u"俺家", u"家"]):
+                    origin = profile[self.SLUG]['origin']
+                else:
+                    origin = self.getLatLng(app_key, start_Point)
+                self.routes = self.getRoutes(app_key, origin, destination)
+
+                # 播放第一条较方便的路线
+                self.say('共找到了{}条路线，这是第一条:{}, 想听别的路线还是打车信息？'.format(len(self.routes)-1, self.routes[0]))
+
+    def isValidImmersive(self, text, parsed):
+        return self.nlu.hasIntent(self.parsed, 'FIND_DIRECTION') or \
+            any(word in text for word in ['退出', '结束', '可以不用了', '不用','谢谢','谢啦']) or \
+            (self.hasNumbers(text) and any(word in text for word in ['第', '条'])) or \
+            any(word in text for word in ['打车', '出租车', '计程车'])
+
+    def isValid(self, text, parsed):
+        return self.nlu.hasIntent(self.parsed, 'FIND_DIRECTION')


### PR DESCRIPTION
## BaiduMap ##

* 根据之前的插件Direction的二次优化，主要优化的地方是运用[百度UNIT](https://ai.baidu.com/unit/v2)和多轮询问来提高用户体验以实现语音交互。插件方面依旧保留了[百度LBS的Web服务API](http://lbsyun.baidu.com/index.php?title=webapi)，使用了[Place suggestion](http://lbsyun.baidu.com/index.php?title=webapi/place-suggestion-api)和[Direction API v2.0](http://lbsyun.baidu.com/index.php?title=webapi/direction-api-v2)两个接口。
* 目前能提供多条公交路线（通常五条）并优先播放耗时时间较短的路线，还能提供打车的费用和耗时。
* 首先，需要在[百度地图开放平台](http://lbsyun.baidu.com/apiconsole/key)注册创建应用以获取app_key，切记！
* 源码：[https://github.com/wzpan/wukong-contrib/blob/HEAD/BaiduMap.py](https://github.com/wzpan/wukong-contrib/blob/HEAD/BaiduMap.py)

### 配置
1. 首先先去[这里](http://api.map.baidu.com/lbsapi/getpoint/)输入你家的地址以获取经纬度。
2. 接着再去[百度地图开放平台](http://lbsyun.baidu.com/apiconsole/key)以获取app_key。
3. 然后在 config.yml 中添加如下配置。

``` yml
# 百度地图路线规划插件
# http://lbsyun.baidu.com/index.php?title=webapi
BaiduMap:
    app_key: 你申请到的app_key
    origin: 例子"39.91405,116.404269",切记切记纬度在前，经度在后，不然报错！
```
### 依赖安装

依赖 jsonpath 库：

``` bash
pip install jsonpath
```

### 交互示例
- 用户：帮我导航呗 / 我想从我家去个地方，帮我导航 / 布吉地铁站怎么走呀
- 悟空：想从哪里出发呢？ / 想去哪里呢？ / 那你是从哪里出发呀？
- 用户：从后海到南山地铁站 / 去布吉吧 / 从家里出发 （多轮询问后直到得到关键信息）
- 悟空：共找到了5条路线，这是第一条:茶光站乘7号线经过12站到福民站,接着福民站乘4号线经过1站到会展中心站,这条路线约耗时48分钟,想听别的路线还是打车信息？（类似这样的回复）
- 用户：想听听第二条路线
- 悟空：茶光站乘7号线经过10站到石厦站,接着福田区委站乘m390路经过3站到会展中心站,这条路线约耗时54分钟,想听别的路线还是打车信息？
- 用户：那么打车的呢？
- 悟空：坐出租车的话需要20分钟,白天大概要30块，黑夜就要45块，超贵的，对不对？还想听别的路线吗？
- 用户：可以，不用了
- 悟空：路上要小心哦！

### 关于百度UNIT
* 由于这次运用百度UNIT来到达获取意图和词槽(提取出发点和目的点)，所以在百度UNIT后台给它足够不同的询问方式(例：简直了，那地方太难找，帮我导航)到模型里，这样就可以识别到导航意图并触发此插件。
* 至于要百度UNIT识别出海量的目的地，个人强烈建议自建百度UNIT的API以供给此插件使用，来到[搜狗输入法网站](https://pinyin.sogou.com/dict/cate/index/306)获取你目前城市的街道/地铁信息，并将大量街道和地铁名给百度UNIT学习。
  * 搜索输入法网站提供下载.scel文件，来到[这里](http://tools.bugscaner.com/sceltotxt/)将 .scel文件转为.txt文件。
* 最后，想学习和自建UNIT技能可以看看[此视频](http://bit.baidu.com/Course/detail/id/252.html)（免费的！），讲得很详细手把手教学。

### UNIT技能
* 分享码 -- y6zae5