### PR TITLE
feat(plugins): 新增网易云播放器插件

### DIFF
--- a/WangYiYun.py
+++ b/WangYiYun.py
@@ -3,12 +3,10 @@ import shutil
 import re
 import cn2an
 import math
-import subprocess
-import platform
 from random import shuffle
 from robot.sdk.AbstractPlugin import AbstractPlugin
 from robot.Player import MusicPlayer
-from robot import config, logging, constants, utils
+from robot import config, logging, constants
 from sdk import NetEaseApi
 
 logger = logging.getLogger(__name__)

--- a/WangYiYun.py
+++ b/WangYiYun.py
@@ -1,0 +1,391 @@
+# -*- coding: utf-8-*-
+import shutil
+import re
+import cn2an
+import math
+import subprocess
+import platform
+import _thread as thread
+from random import shuffle
+from robot.sdk.AbstractPlugin import AbstractPlugin
+from robot.Player import SoxPlayer
+from robot.sdk import unit
+from robot import config, logging, constants, utils
+from sdk import NetEaseApi
+
+logger = logging.getLogger(__name__)
+
+class WangYiYunPlayer(SoxPlayer):
+    """
+    给网易云播放器插件使用的，
+    在 SOXPlayer 的基础上增加了列表的支持，支持暂停和恢复播放
+    并支持登陆和外接网易云API，返回相关信息
+    """
+    SLUG = 'WangYiYunPlayer'
+
+    def __init__(self, account, md5pass, plugin, **kwargs):
+        super(WangYiYunPlayer, self).__init__(**kwargs)
+        self.account = account
+        self.md5pass = md5pass
+        self.plugin = plugin
+        self.userid = None
+        self.nickname = None
+        self.api = NetEaseApi.NetEase()
+        self.playlist = None
+        self.multi_playlist = None
+        self.random = False
+        self.idx = 0
+        self.list_idx = None
+        self.pausing = False
+        self.last_paused = None
+
+        ## 首次登陆则需发起请求获取cookies，cookies过期则需发起请求
+        if len(self.api.session.cookies) == 0:
+            self.login()
+            #self.daily_checkin()
+        else:
+            self.userid = config.get('/' + self.plugin.SLUG + '/userid')
+            self.nickname = config.get('/' + self.plugin.SLUG + '/nickname')
+            #self.daily_checkin()
+
+    def login(self):
+        resp = self.api.login(self.account, self.md5pass)
+        if resp["code"] == 200:
+            self.userid = resp["account"]["id"]
+            self.nickname = resp["profile"]["nickname"]
+            temp = open('add_info', 'w')
+            with open(constants.getConfigPath(), 'r') as f:
+                for line in f:
+                    if line.startswith('    md5pass'):
+                        line = line + "    userid: \'" + str(self.userid) + "\'\n    nickname: \'" + str(self.nickname) + "\'\n"
+                    temp.write(line)
+            temp.close()
+            shutil.move('add_info', constants.getConfigPath())
+            self.plugin.say('首次登陆成功，哇哈哈哈!', cache=True, wait=True)
+        else:
+            self.plugin.say('登陆失败，是不是密码错了呢？', cache=True, wait=True)
+            logger.error('状态码:{}'.format(resp['code']))
+
+    def daily_checkin(self):
+        res = self.api.daily_task(is_mobile=False)
+        if res["code"] == 200:
+            self.plugin.say('已帮你悄悄的签到了，哇哈哈!', cache=True, wait=True)
+
+    def play(self):
+        logger.debug('MusicPlayer play')
+        path = self.playlist[self.idx]['mp3_url']
+        super().stop()
+        super().play(path, False, self.next)
+
+    def replay(self):
+        logger.debug('MusicPlayer replay')
+        path = self.playlist[self.idx]['mp3_url']
+        super().stop()
+        super().play(path, False, self.replay)
+
+    def next(self):
+        logger.debug('MusicPlayer next')
+        super().stop()
+        self.idx = (self.idx+1) % len(self.playlist)
+        self.play()
+
+    def prev(self):
+        logger.debug('MusicPlayer prev')
+        super().stop()
+        self.idx = (self.idx-1) % len(self.playlist)
+        self.play()
+
+    def pause(self):
+        logger.debug('MusicPlayer pause')
+        self.pausing = True
+
+    def stop(self):
+        if self.proc:
+            logger.debug('MusicPlayer stop')
+            # STOP current play process
+            self.last_paused = utils.write_temp_file(str(self.proc.pid), 'pid', 'w')
+            self.onCompleteds = []
+            subprocess.run(['pkill', '-STOP', '-F', self.last_paused])
+
+    def resume(self):
+        logger.debug('MusicPlayer resume')
+        self.pausing = False
+        self.onCompleteds = [self.next]
+        if self.last_paused is not None:
+            logger.debug(self.last_paused)
+            subprocess.run(['pkill', '-CONT', '-F', self.last_paused])
+
+    def is_playing(self):
+        return self.playing
+
+    def is_pausing(self):
+        return self.pausing
+
+    def turnUp(self):
+        system = platform.system()
+        if system == 'Darwin':
+            res = subprocess.run(['osascript', '-e', 'output volume of (get volume settings)'], shell=False, capture_output=True, text=True)
+            volume = int(res.stdout.strip())
+            volume += 20
+            if volume >= 100:
+                volume = 100
+                self.plugin.say('音量已经最大啦', wait=True)
+            subprocess.run(['osascript', '-e', 'set volume output volume {}'.format(volume)])
+        elif system == 'Linux':
+            res = subprocess.run(["amixer sget Master | grep 'Mono:' | awk -F'[][]' '{ print $2 }'"], shell=True, capture_output=True, text=True)
+            logger.info(res.stdout)
+            if res.stdout != '' and res.stdout.strip().endswith('%'):
+                volume = int(res.stdout.strip().replace('%', ''))
+                volume += 20
+                if volume >= 100:
+                    volume = 100
+                    self.plugin.say('音量已经最大啦', wait=True)
+                subprocess.run(['amixer', 'set', 'Master', '{}%'.format(volume)])
+            else:
+                subprocess.run(['amixer', 'set', 'Master', '20%+'])
+        else:
+            self.plugin.say('当前系统不支持调节音量', wait=True)
+        self.resume()
+
+    def turnDown(self):
+        system = platform.system()
+        if system == 'Darwin':
+            res = subprocess.run(['osascript', '-e', 'output volume of (get volume settings)'], shell=False, capture_output=True, text=True)
+            volume = int(res.stdout.strip())
+            volume -= 20
+            if volume <= 20:
+                volume = 20
+                self.plugin.say('音量已经很小啦', wait=True)
+            subprocess.run(['osascript', '-e', 'set volume output volume {}'.format(volume)])
+        elif system == 'Linux':
+            res = subprocess.run(["amixer sget Master | grep 'Mono:' | awk -F'[][]' '{ print $2 }'"], shell=True, capture_output=True, text=True)
+            if res.stdout != '' and res.stdout.endswith('%'):
+                volume = int(res.stdout.replace('%', '').strip())
+                volume -= 20
+                if volume <= 20:
+                    volume = 20
+                    self.plugin.say('音量已经最小啦', wait=True)
+                subprocess.run(['amixer', 'set', 'Master', '{}%'.format(volume)])
+            else:
+                subprocess.run(['amixer', 'set', 'Master', '20%-'])
+        else:
+            self.plugin.say('当前系统不支持调节音量', wait=True)
+        self.resume()
+
+    def get_recommend_songs(self):
+        datalist = self.api.dig_info(self.api.recommend_playlist(), 'songs')
+        return self.pack_info(datalist, "song_id", "song_name", "artist", "album_name", "mp3_url", "quality")
+
+    def get_recommend_playlist(self):
+        datalist = self.api.dig_info(self.api.recommend_resource(), 'top_playlists')
+        self.multi_playlist = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
+        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][:5]
+        say_info = ''
+        for idx, name in enumerate(playlist_name, start=1):
+            say_info = say_info + '第{}张叫：{}。'.format(idx, name)
+        return say_info
+
+    def get_user_playlist(self):
+        datalist = self.api.dig_info(self.api.user_playlist(self.userid), 'top_playlists')
+        self.multi_playlist = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
+        if len(self.multi_playlist) > 5:
+            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][:5]
+        else:
+            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist]
+        say_info = ''
+        for idx, name in enumerate(playlist_name, start=1):
+            say_info = say_info + '第{}张叫：{}。'.format(idx, name)
+        return say_info
+
+    def get_playlist_detail(self, list_id):
+        datalist = self.api.dig_info(self.api.playlist_detail(list_id), 'songs')
+        return self.pack_info(datalist, "song_id", "song_name", "artist", "album_name", "mp3_url", "quality")
+
+    def get_playlists_portions(self, idx):
+        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][(idx-1)*5:(idx)*5]
+        say_info = ''
+        for idx, name in enumerate(playlist_name, start=(idx-1)*5+1):
+            say_info = say_info + '第{}张叫：{}。'.format(idx, name)
+        return say_info
+
+    def pack_info(self, datalist, *args):
+        result = []
+        for data in datalist:
+            info = {}
+            for item in args:
+                info.setdefault(item, data.get(item))
+            result.append(info)
+        return result
+
+    def shuffle_songs(self):
+        if self.playlist:
+            shuffle(self.playlist)
+
+class Plugin(AbstractPlugin):
+    IS_IMMERSIVE = True  # 这是个沉浸式技能
+    SLUG = "WangYiYun"
+
+    def __init__(self, con):
+        super(Plugin, self).__init__(con)
+        self.player = None
+        self.playlist_number_cut = 1
+
+    def hasNumbers(self, inputString):
+        return any(char.isnumeric() for char in inputString if '什' != char)
+
+    def whichNumber(self, text):
+        number = re.compile(r"(\d+\.?\d*|[一二三四五六七八九零十百千万亿]+|[0-9]+[,]*[0-9]+.[0-9]+)")
+        listNumber = number.findall(text)[0]
+        return int(listNumber) if listNumber.isdigit() else cn2an.cn2an(listNumber, "normal")
+
+    def handle(self, text, parsed):
+        ##需在配置文件给百度地图的API
+        profile = config.get()
+        if self.SLUG not in profile or \
+           'account' not in profile[self.SLUG] or \
+           'md5pass' not in profile[self.SLUG]:
+            self.say(u"你得在配置文件调整一下呀，哼！", cache=True)
+            return
+        if not self.player:
+            self.player = WangYiYunPlayer(profile[self.SLUG]['account'], profile[self.SLUG]['md5pass'], self)
+
+        # 插件核心处理逻辑
+        ##################################获取每日推荐歌曲####################################
+        if any(word in text for word in ['推荐歌曲', '推荐的歌', '歌推荐', '每日推荐']):
+            self.player.playlist = self.player.get_recommend_songs()
+            logger.info([song['song_name'] for song in self.player.playlist])
+            self.say('一共有{}首推荐歌曲噢！'.format(len(self.player.playlist)), wait=True)
+            self.player.play()
+
+        ###################################获取每日推荐歌单####################################
+        elif any(word in text for word in ['推荐歌单', '歌单推荐']):
+            playlists_info = self.player.get_recommend_playlist()
+            self.playlist_number_cut += 1
+            logger.info(playlists_info)
+            self.say('共找到了{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '想听哪一张，或者要不要继续听下去呢？')
+
+        ###################################获取我的歌单####################################
+        elif any(word in text for word in ['我的歌单', '网易云歌单']):
+            playlists_info = self.player.get_user_playlist()
+            logger.info(playlists_info)
+            if len(self.player.multi_playlist) > 5:
+                self.playlist_number_cut += 1
+                self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '想听哪一张，或者要不要继续听下去呢？')
+            else:
+                self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '你想听哪一张呢？')
+
+        ###################################播放更多的歌单####################################
+        elif any(word in text for word in ['继续听', '听下去', '重新报']) and self.player.multi_playlist:
+            playlists_info = self.player.get_playlists_portions(self.playlist_number_cut)
+            self.playlist_number_cut += 1
+            logger.info(playlists_info)
+            if self.playlist_number_cut  > math.ceil(len(self.player.multi_playlist)/5):
+                self.say(playlists_info + '你想听哪一张呢，就这么多歌单了，要我重新报一次吗？')
+                self.playlist_number_cut = 1
+            else:
+                self.say(playlists_info + '你想听哪一张呢，还是要不要听下去呢？')
+
+        ###################################询问歌单名字或者当前歌名####################################
+        elif any(word in text for word in ['啥', '什么', '叫']):
+            if self.player.multi_playlist and u"歌单" in text:
+                if self.player.list_idx:
+                    self.say('目前播放的歌单叫{}！'.format(self.player.multi_playlist[self.player.list_idx]['playlist_name']), wait=True)
+                    self.player.resume()
+                elif self.hasNumbers(text):
+                    listNumber = self.whichNumber(text) - 1
+                    if listNumber < len(self.player.multi_playlist):
+                        self.say('第{}歌单叫{}！'.format(listNumber+1, self.player.multi_playlist[listNumber]['playlist_name']))
+                    else:
+                        self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlist)))
+                else:
+                    self.say('你都还没有选歌单呢，我咋知道，哼！', cache=True)
+            elif self.player.playlist:
+                logger.info(self.player.playlist[self.player.idx])
+                self.say('这首歌叫{}, 是{}唱的！'.format(self.player.playlist[self.player.idx]['song_name'], self.player.playlist[self.player.idx]['artist']), wait=True)
+                self.player.resume()
+            else:
+                self.say('你都没有播放歌曲，我咋知道，哼！', cache=True)
+
+        ###################################询问歌单名字或者当前歌名####################################
+        elif u"收藏" in text and self.player.playlist:
+            if u"歌单" in text and self.player.list_idx:
+                if self.player.api.subscribe_playlist(self.player.multi_playlist[self.player.list_idx]['playlist_id']):
+                    self.say('目前的歌单已收藏成功！', cache=True, wait=True)
+                else:
+                    self.say('这歌单收藏失败，估计之前就收藏了吧', cache=True, wait=True)
+                self.player.resume()
+            elif u"歌" in text:
+                if self.player.api.like_song(self.player.playlist[self.player.idx]['song_id']):
+                    self.say('这歌已收藏成功啦！', cache=True, wait=True)
+                else:
+                    self.say('这歌收藏失败了，估计之前就收藏了吧', cache=True, wait=True)
+                self.player.resume()
+            else:
+                self.say('你得告诉是要收藏歌单还是歌呀！哼！', cache=True, wait=True)
+                self.player.resume()
+
+        ###################################选择哪一张歌单####################################
+        elif self.hasNumbers(text) and any(word in text for word in ['第', '张']) and self.player.multi_playlist:
+            listNumber = self.whichNumber(text) - 1
+            if listNumber < len(self.player.multi_playlist):
+                self.player.list_idx = listNumber
+                self.player.playlist = self.player.get_playlist_detail(self.player.multi_playlist[listNumber]['playlist_id'])
+                self.player.shuffle_songs()
+                self.playlist_number_cut = 1
+                logger.info([each_song['song_name'] for each_song in self.player.playlist])
+                self.say('选择了第{}张'.format(listNumber+1), wait=True)
+                self.player.play()
+            else:
+                self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlist)), onCompleted=lambda: self.con.doResponse(self.activeListen()))
+        
+        ###################################播放器的基本操作####################################
+        elif self.nlu.hasIntent(parsed, 'CHANGE_TO_NEXT'):
+            self.say('下一首歌', cache=True, wait=True)
+            self.player.next()
+        elif self.nlu.hasIntent(parsed, 'CHANGE_TO_LAST'):
+            self.say('上一首歌', cache=True, wait=True)
+            self.player.prev()
+        elif self.nlu.hasIntent(parsed, 'CHANGE_VOL'):
+            slots = self.nlu.getSlots(parsed, 'CHANGE_VOL')
+            for slot in slots:
+                if slot['name'] == 'user_d':
+                    word = self.nlu.getSlotWords(parsed, 'CHANGE_VOL', 'user_d')[0]
+                    if word == '--HIGHER--':
+                        self.player.turnUp()
+                    else:
+                        self.player.turnDown()
+                    return
+                elif slot['name'] == 'user_vd':
+                    word = self.nlu.getSlotWords(parsed, 'CHANGE_VOL', 'user_vd')[0]
+                    if word == '--LOUDER--':
+                        self.player.turnUp()
+                    else:
+                        self.player.turnDown()
+        elif self.nlu.hasIntent(parsed, 'PAUSE'):
+            self.player.pause()
+        elif self.nlu.hasIntent(parsed, 'CONTINUE'):
+            self.player.resume()
+        elif self.nlu.hasIntent(parsed, 'RESTART_MUSIC'):
+            self.player.play()
+        elif self.nlu.hasIntent(parsed, 'CLOSE_MUSIC') or u"退出" in text:
+            self.player.stop()
+            self.clearImmersive()  # 去掉沉浸式
+            self.say('退出网易云', cache=True)
+        else:
+            self.say('你想播放什么呢？推荐歌曲，推荐歌单还是你的歌单？', cache=True)
+
+    def pause(self):
+        if self.player:
+            self.player.stop()
+
+    def restore(self):
+        if self.player and not self.player.is_pausing():
+            self.player.resume()
+
+    def isValidImmersive(self, text, parsed):
+        return any(self.nlu.hasIntent(parsed, intent) for intent in ['CHANGE_TO_LAST', 'CHANGE_TO_NEXT', 'CHANGE_VOL', 'CLOSE_MUSIC', 'PAUSE', 'CONTINUE', 'RESTART_MUSIC']) or \
+        any(word in text for word in [u"歌单", u"推荐", u"什么", u"啥", u"继续", u"听", u"退出", u"第", u"收藏"])
+
+    def isValid(self, text, parsed):
+        return u"网易云" in text or \
+        (u"网易云" in text and any(word in text for word in [u"歌单", u"推荐"]))

--- a/WangYiYun.py
+++ b/WangYiYun.py
@@ -7,35 +7,29 @@ import subprocess
 import platform
 from random import shuffle
 from robot.sdk.AbstractPlugin import AbstractPlugin
-from robot.Player import SoxPlayer
+from robot.Player import MusicPlayer
 from robot import config, logging, constants, utils
 from sdk import NetEaseApi
 
 logger = logging.getLogger(__name__)
 
-class WangYiYunPlayer(SoxPlayer):
+class WangYiYunPlayer(MusicPlayer):
     """
     给网易云播放器插件使用的，
-    在 SOXPlayer 的基础上增加了列表的支持，支持暂停和恢复播放
-    并支持登陆和外接网易云API，返回相关信息
+    在 MusicPlayer 的基础上支持登陆和外接网易云API，返回相关信息。
     """
     SLUG = 'WangYiYunPlayer'
 
-    def __init__(self, account, md5pass, plugin, **kwargs):
-        super(WangYiYunPlayer, self).__init__(**kwargs)
+    def __init__(self, account, md5pass, playlist, plugin, **kwargs):
+        super(WangYiYunPlayer, self).__init__(playlist, plugin, **kwargs)
         self.account = account
         self.md5pass = md5pass
-        self.plugin = plugin
         self.userid = None
         self.nickname = None
         self.api = NetEaseApi.NetEase()
-        self.playlist = None
-        self.multi_playlist = None
-        self.random = False
-        self.idx = 0
+        self.playlist_info = None
+        self.multi_playlists = None
         self.list_idx = None
-        self.pausing = False
-        self.last_paused = None
 
         ## 首次登陆则需发起请求获取cookies，cookies过期则需发起请求
         if len(self.api.session.cookies) == 0:
@@ -45,6 +39,12 @@ class WangYiYunPlayer(SoxPlayer):
             self.userid = config.get('/' + self.plugin.SLUG + '/userid')
             self.nickname = config.get('/' + self.plugin.SLUG + '/nickname')
             self.daily_checkin()
+ 
+    def replay(self):
+        logger.debug('WangYiYunPlayer replay')
+        path = self.playlist[self.idx]
+        super().stop()
+        super(MusicPlayer, self).play(path, False, self.replay)
 
     def login(self):
         resp = self.api.login(self.account, self.md5pass)
@@ -71,115 +71,14 @@ class WangYiYunPlayer(SoxPlayer):
         if res["code"] == 200:
             self.plugin.say('已帮你悄悄的签到了，哇哈哈!', cache=True, wait=True)
 
-    def play(self):
-        logger.debug('MusicPlayer play')
-        path = self.playlist[self.idx]['mp3_url']
-        super().stop()
-        super().play(path, False, self.next)
-
-    def replay(self):
-        logger.debug('MusicPlayer replay')
-        path = self.playlist[self.idx]['mp3_url']
-        super().stop()
-        super().play(path, False, onCompleted=self.replay)
-
-    def next(self):
-        logger.debug('MusicPlayer next')
-        super().stop()
-        self.idx = (self.idx+1) % len(self.playlist)
-        self.play()
-
-    def prev(self):
-        logger.debug('MusicPlayer prev')
-        super().stop()
-        self.idx = (self.idx-1) % len(self.playlist)
-        self.play()
-
-    def pause(self):
-        logger.debug('MusicPlayer pause')
-        self.pausing = True
-
-    def stop(self):
-        if self.proc:
-            logger.debug('MusicPlayer stop')
-            # STOP current play process
-            self.last_paused = utils.write_temp_file(str(self.proc.pid), 'pid', 'w')
-            self.onCompleteds = []
-            subprocess.run(['pkill', '-STOP', '-F', self.last_paused])
-
-    def resume(self):
-        logger.debug('MusicPlayer resume')
-        self.pausing = False
-        self.onCompleteds = [self.next]
-        if self.last_paused is not None:
-            logger.debug(self.last_paused)
-            subprocess.run(['pkill', '-CONT', '-F', self.last_paused])
-
-    def is_playing(self):
-        return self.playing
-
-    def is_pausing(self):
-        return self.pausing
-
-    def turnUp(self):
-        system = platform.system()
-        if system == 'Darwin':
-            res = subprocess.run(['osascript', '-e', 'output volume of (get volume settings)'], shell=False, capture_output=True, text=True)
-            volume = int(res.stdout.strip())
-            volume += 20
-            if volume >= 100:
-                volume = 100
-                self.plugin.say('音量已经最大啦', wait=True)
-            subprocess.run(['osascript', '-e', 'set volume output volume {}'.format(volume)])
-        elif system == 'Linux':
-            res = subprocess.run(["amixer sget Master | grep 'Mono:' | awk -F'[][]' '{ print $2 }'"], shell=True, capture_output=True, text=True)
-            logger.info(res.stdout)
-            if res.stdout != '' and res.stdout.strip().endswith('%'):
-                volume = int(res.stdout.strip().replace('%', ''))
-                volume += 20
-                if volume >= 100:
-                    volume = 100
-                    self.plugin.say('音量已经最大啦', wait=True)
-                subprocess.run(['amixer', 'set', 'Master', '{}%'.format(volume)])
-            else:
-                subprocess.run(['amixer', 'set', 'Master', '20%+'])
-        else:
-            self.plugin.say('当前系统不支持调节音量', wait=True)
-        self.resume()
-
-    def turnDown(self):
-        system = platform.system()
-        if system == 'Darwin':
-            res = subprocess.run(['osascript', '-e', 'output volume of (get volume settings)'], shell=False, capture_output=True, text=True)
-            volume = int(res.stdout.strip())
-            volume -= 20
-            if volume <= 20:
-                volume = 20
-                self.plugin.say('音量已经很小啦', wait=True)
-            subprocess.run(['osascript', '-e', 'set volume output volume {}'.format(volume)])
-        elif system == 'Linux':
-            res = subprocess.run(["amixer sget Master | grep 'Mono:' | awk -F'[][]' '{ print $2 }'"], shell=True, capture_output=True, text=True)
-            if res.stdout != '' and res.stdout.endswith('%'):
-                volume = int(res.stdout.replace('%', '').strip())
-                volume -= 20
-                if volume <= 20:
-                    volume = 20
-                    self.plugin.say('音量已经最小啦', wait=True)
-                subprocess.run(['amixer', 'set', 'Master', '{}%'.format(volume)])
-            else:
-                subprocess.run(['amixer', 'set', 'Master', '20%-'])
-        else:
-            self.plugin.say('当前系统不支持调节音量', wait=True)
-        self.resume()
-
     def get_recommend_songs(self):
         datalist = self.api.dig_info(self.api.recommend_playlist(), 'songs')
         return self.pack_info(datalist, "song_id", "song_name", "artist", "album_name", "mp3_url", "quality")
 
     def get_recommend_playlist(self):
         datalist = self.api.dig_info(self.api.recommend_resource(), 'top_playlists')
-        self.multi_playlist = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
-        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][:5]
+        self.multi_playlists = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
+        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlists][:5]
         say_info = ''
         for idx, name in enumerate(playlist_name, start=1):
             say_info = say_info + '第{}张叫：{}。'.format(idx, name)
@@ -187,11 +86,11 @@ class WangYiYunPlayer(SoxPlayer):
 
     def get_user_playlist(self):
         datalist = self.api.dig_info(self.api.user_playlist(self.userid), 'top_playlists')
-        self.multi_playlist = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
-        if len(self.multi_playlist) > 5:
-            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][:5]
+        self.multi_playlists = self.pack_info(datalist, "playlist_id", "playlist_name", "creator_name")
+        if len(self.multi_playlists) > 5:
+            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlists][:5]
         else:
-            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist]
+            playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlists]
         say_info = ''
         for idx, name in enumerate(playlist_name, start=1):
             say_info = say_info + '第{}张叫：{}。'.format(idx, name)
@@ -202,7 +101,7 @@ class WangYiYunPlayer(SoxPlayer):
         return self.pack_info(datalist, "song_id", "song_name", "artist", "album_name", "mp3_url", "quality")
 
     def get_playlists_portions(self, idx):
-        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlist][(idx-1)*5:(idx)*5]
+        playlist_name = [each_list['playlist_name'] for each_list in self.multi_playlists][(idx-1)*5:(idx)*5]
         say_info = ''
         for idx, name in enumerate(playlist_name, start=(idx-1)*5+1):
             say_info = say_info + '第{}张叫：{}。'.format(idx, name)
@@ -239,11 +138,11 @@ class Plugin(AbstractPlugin):
         return int(listNumber) if listNumber.isdigit() else cn2an.cn2an(listNumber, "normal")
 
     def handle_playlists(self, input):
-        if any(word in input for word in [u"我要", u"好", u"继续", u"听"]) and len(self.player.multi_playlist) > 5:
+        if any(word in input for word in [u"我要", u"好", u"继续", u"听"]) and len(self.player.multi_playlists) > 5:
             playlists_info = self.player.get_playlists_portions(self.playlist_number_cut)
             self.playlist_number_cut += 1
             logger.info(playlists_info)
-            if self.playlist_number_cut  > math.ceil(len(self.player.multi_playlist)/5):
+            if self.playlist_number_cut  > math.ceil(len(self.player.multi_playlists)/5):
                 self.say(playlists_info + '你想听哪一张呢，就这么多歌单了，要我重新报一次吗？', onCompleted=lambda: self.handle_playlists(self.activeListen()))
             else:
                 self.say(playlists_info + '你想听哪一张呢，还是要不要听下去呢', onCompleted=lambda: self.handle_playlists(self.activeListen()))
@@ -255,22 +154,23 @@ class Plugin(AbstractPlugin):
 
         elif any(word in input for word in ['啥', '什么', '叫']) and self.hasNumbers(input):
             listNumber = self.whichNumber(input) - 1
-            if listNumber < len(self.player.multi_playlist):
-                self.say('第{}歌单叫{}！'.format(listNumber+1, self.player.multi_playlist[listNumber]['playlist_name']), onCompleted=lambda: self.handle_playlists(self.activeListen()))
+            if listNumber < len(self.player.multi_playlists):
+                self.say('第{}歌单叫{}！'.format(listNumber+1, self.player.multi_playlists[listNumber]['playlist_name']), onCompleted=lambda: self.handle_playlists(self.activeListen()))
             else:
-                self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlist)), onCompleted=lambda: self.handle_playlists(self.activeListen()))
+                self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlists)), onCompleted=lambda: self.handle_playlists(self.activeListen()))
 
         elif u"第" in input and self.hasNumbers(input):
             listNumber = self.whichNumber(input) - 1
-            if listNumber < len(self.player.multi_playlist):
+            if listNumber < len(self.player.multi_playlists):
                 self.player.list_idx = listNumber
-                self.player.playlist = self.player.get_playlist_detail(self.player.multi_playlist[listNumber]['playlist_id'])
+                self.player.playlist_info = self.player.get_playlist_detail(self.player.multi_playlists[listNumber]['playlist_id'])
+                self.player.playlist = [each_song['mp3_url'] for each_song in self.player.playlist_info]
                 self.player.shuffle_songs()
-                #logger.debug([each_song['song_name'] for each_song in self.player.playlist])
+                #logger.debug([each_song['song_name'] for each_song in self.player.playlist_info])
                 self.say('选择了第{}张'.format(listNumber+1), wait=True)
                 self.player.play()
             else:
-                self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlist)), onCompleted=lambda: self.handle_playlists(self.activeListen()))
+                self.say('都说了只有{}张歌单啦，哼！'.format(len(self.player.multi_playlists)), onCompleted=lambda: self.handle_playlists(self.activeListen()))
         
         elif any(word in input for word in [u"不要", u"算了", u"不用"]):
             self.say('哼！白浪费帮你找来了这么多歌单。', cache=True)
@@ -287,13 +187,14 @@ class Plugin(AbstractPlugin):
             self.say(u"你得在配置文件调整一下呀，哼！", cache=True)
             return
         if not self.player:
-            self.player = WangYiYunPlayer(profile[self.SLUG]['account'], profile[self.SLUG]['md5pass'], self)
+            self.player = WangYiYunPlayer(profile[self.SLUG]['account'], profile[self.SLUG]['md5pass'], None, self)
 
         try:
             # 插件核心处理逻辑
             ##################################获取每日推荐歌曲####################################
             if any(word in text for word in ['推荐歌曲', '推荐的歌曲', '歌推荐', '每日推荐']):
-                self.player.playlist = self.player.get_recommend_songs()
+                self.player.playlist_info = self.player.get_recommend_songs()
+                self.player.playlist = [each_song['mp3_url'] for each_song in self.player.playlist_info]
                 self.say('一共有{}首推荐歌曲噢！'.format(len(self.player.playlist)), wait=True)
                 self.player.play()
 
@@ -302,42 +203,42 @@ class Plugin(AbstractPlugin):
                 playlists_info = self.player.get_recommend_playlist()
                 self.playlist_number_cut += 1
                 logger.info(playlists_info)
-                self.say('共找到了{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '想听哪一张，或者要不要继续听下去呢', onCompleted=lambda: self.handle_playlists(self.activeListen()))
+                self.say('共找到了{}张歌单哦！'.format(len(self.player.multi_playlists)) + playlists_info + '想听哪一张，或者要不要继续听下去呢', onCompleted=lambda: self.handle_playlists(self.activeListen()))
 
             ###################################获取我的歌单####################################
-            elif any(word in text for word in ['我的歌单', '网易云歌单']):
+            elif u"我的歌单" in text or u"网易云歌单" in text:
                 playlists_info = self.player.get_user_playlist()
                 logger.info(playlists_info)
-                if len(self.player.multi_playlist) > 5:
+                if len(self.player.multi_playlists) > 5:
                     self.playlist_number_cut += 1
-                    self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '想听哪一张，或者要不要继续听下去呢', onCompleted=lambda: self.handle_playlists(self.activeListen()))
+                    self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlists)) + playlists_info + '想听哪一张，或者要不要继续听下去呢', onCompleted=lambda: self.handle_playlists(self.activeListen()))
                 else:
-                    self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlist)) + playlists_info + '你想听哪一张呢，或者需要我重新报一次吗', onCompleted=lambda: self.handle_playlists(self.activeListen()))
+                    self.say('你一共有{}张歌单哦！'.format(len(self.player.multi_playlists)) + playlists_info + '你想听哪一张呢，或者需要我重新报一次吗', onCompleted=lambda: self.handle_playlists(self.activeListen()))
 
             ###################################询问歌单名字或者当前歌名####################################
             elif self.player.playlist and any(word in text for word in ['啥', '什么', '叫']):
-                if self.player.multi_playlist and u"歌单" in text:
+                if self.player.multi_playlists and u"歌单" in text:
                     if self.player.list_idx:
-                        logger.info(self.player.multi_playlist[self.player.list_idx]['playlist_name'])
-                        self.say('目前播放的歌单叫{}！'.format(self.player.multi_playlist[self.player.list_idx]['playlist_name']), wait=True)
+                        logger.info(self.player.multi_playlists[self.player.list_idx]['playlist_name'])
+                        self.say('目前播放的歌单叫{}！'.format(self.player.multi_playlists[self.player.list_idx]['playlist_name']), wait=True)
                         self.player.resume()
                     else:
                         self.say('你选的推荐歌曲，怎么会有歌单名呢，哼！', cache=True)
                 else:
-                    logger.info(self.player.playlist[self.player.idx])
-                    self.say('这首歌叫{}, 是{}唱的！'.format(self.player.playlist[self.player.idx]['song_name'], self.player.playlist[self.player.idx]['artist']), wait=True)
+                    logger.info(self.player.playlist_info[self.player.idx])
+                    self.say('这首歌叫{}, 是{}唱的！'.format(self.player.playlist_info[self.player.idx]['song_name'], self.player.playlist_info[self.player.idx]['artist']), wait=True)
                     self.player.resume()
 
             ###################################收藏当前播放的歌曲或歌单###########################################
             elif self.player.playlist and self.nlu.hasIntent(parsed, 'SAVE'):
                 if u"歌单" in text and self.player.list_idx:
-                    if self.player.api.subscribe_playlist(self.player.multi_playlist[self.player.list_idx]['playlist_id']):
+                    if self.player.api.subscribe_playlist(self.player.multi_playlists[self.player.list_idx]['playlist_id']):
                         self.say('目前的歌单已收藏成功！', cache=True, wait=True)
                     else:
                         self.say('这歌单收藏失败，估计之前就收藏了吧', cache=True, wait=True)
                     self.player.resume()
                 elif u"歌" in text:
-                    if self.player.api.like_song(self.player.playlist[self.player.idx]['song_id']):
+                    if self.player.api.like_song(self.player.playlist_info[self.player.idx]['song_id']):
                         self.say('这歌已收藏成功啦！', cache=True, wait=True)
                     else:
                         self.say('这歌收藏失败了，估计之前就收藏了吧', cache=True, wait=True)

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -523,4 +523,56 @@ SmartMiFan:
 | $num $unit 后关闭风扇 | $num 是数字，$unit 可以是秒/分钟/小时  | 预约关机 |
 
 
+## WangYiYun ##
 
+* 根据Github上的[musicbox](https://github.com/darknessomi/musicbox)所提供的api文件进行抽离和修改，当中也要感谢wzpan大佬之前写的[API](https://github.com/wzpan/MusicBoxApi)。
+* 目前主要围绕**每日推荐歌单**，**每日推荐歌曲**和**我的歌单**功能进行开发，其中还包括**自动签到**，**收藏歌单和歌曲**, **询问当前播放歌曲信息**和**基本播放器**功能，往后还会有更多功能请敬请期待一下。
+* 花费的时间较多在if-else的逻辑判断，也就是插件的handle方法，欢迎大家多出建议和问题来改良（代码稍微有些欠缺）。
+* 源码：[https://github.com/wzpan/wukong-contrib/blob/HEAD/BaiduMap.py](https://github.com/wzpan/wukong-contrib/blob/HEAD/WangYiYun.py)
+
+### 配置
+1. 首先请将账号信息配置在config.yml，如以下的方式配置。
+``` yml
+# 网易云音乐插件
+WangYiYun:
+    account: 'XXXXXXXX'  # 网易云音乐账号
+    #密码的 md5，可以用 python3 wukong.py md5 "密码" 获得
+    md5pass: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx' 
+```
+2. 将~/.wukong/contrib主库更新一下以获取WangYiYun.py插件，还有需要下载一些额外的第三方库。
+``` sh
+git pull
+pip3 install -r requirements.txt
+``` 
+
+### 关于首次登陆的那些事
+* 首次登陆会通过账号信息尝试获取两周有效期的Cookies并保存于本地~/.wukong/，同时会定期检查有效期。
+* ~/.wukong/文件有一个名为reqcache文件，用于requests的缓存。
+* 首次登陆后会在config.yml写入userid和nickname，便于往后的查询请求。
+
+
+### 交互示例
+> 为了简化交互和满足不同的问句，一次的播报信息中只会包含五个歌单名称，可以对悟空喊：“我想听下去”来了解更多歌单名称。
+---> 每日推荐歌单 / 我的歌单
+- 用户：打开网易云的推荐歌单 / 打开我的网易云歌单
+- 悟空：共找到X张歌单，第1张叫XXX，第2张叫XXX...想听哪一张，或者要不要继续听下去呢？
+- 用户：我想听下去 / 我要继续听更多
+- 悟空：共找到X张歌单，第6张叫XXX，第7张叫XXX...想听哪一张，或者要不要继续听下去呢？
+- 用户：刚刚第4张歌单叫什么来的
+- 悟空：第四张歌单叫XXXX
+- 用户：那我要听第4张
+- 悟空：选了第4张
+
+---> 每日推荐歌曲
+- 用户：打开网易云的推荐歌曲
+- 悟空：一共有X首推荐歌曲噢！（然后播放歌曲）
+
+---> 播放歌曲时的语句：
+- 用户：这首歌叫什么
+- 悟空：这首歌叫XXX，是XXX唱的
+- 用户：这张歌单叫什么名字
+- 悟空：目前播放的歌单叫XXX
+- 用户：我想要收藏这首歌  / 我要收藏这个歌单
+- 悟空：这首歌已帮你收藏成功 / 目前的歌单已收藏成功！
+- 用户：再放一遍吧
+- 悟空：重新播放当前的歌曲

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 paho-mqtt>=1.3.0
 eyeD3>=0.8
+cn2an==0.3.7
+requests_cache==0.5.2

--- a/sdk/NetEaseApi.py
+++ b/sdk/NetEaseApi.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# @Author: omi
+# @Date:   2014-08-24 21:51:57
+'''
+网易云音乐 Api
+'''
+from builtins import chr
+from builtins import int
+from builtins import map
+from builtins import open
+from builtins import range
+from builtins import str
+from builtins import pow
+
+import re
+import os
+import json
+import time
+import hashlib
+import random
+import base64
+import binascii
+import sys
+
+from Crypto.Cipher import AES
+from http.cookiejar import LWPCookieJar
+import requests
+import requests_cache
+from robot import constants, logging
+log = logging.getLogger(__name__)
+
+class TooManyTracksException(Exception):
+    """The playlist contains more than 1000 tracks."""
+    pass
+
+# 歌曲榜单地址
+top_list_all = {
+    0: ['云音乐新歌榜', '/discover/toplist?id=3779629'],
+    1: ['云音乐热歌榜', '/discover/toplist?id=3778678'],
+    2: ['网易原创歌曲榜', '/discover/toplist?id=2884035'],
+    3: ['云音乐飙升榜', '/discover/toplist?id=19723756'],
+    4: ['云音乐电音榜', '/discover/toplist?id=10520166'],
+    5: ['UK排行榜周榜', '/discover/toplist?id=180106'],
+    6: ['美国Billboard周榜', '/discover/toplist?id=60198'],
+    7: ['KTV嗨榜', '/discover/toplist?id=21845217'],
+    8: ['iTunes榜', '/discover/toplist?id=11641012'],
+    9: ['Hit FM Top榜', '/discover/toplist?id=120001'],
+    10: ['日本Oricon周榜', '/discover/toplist?id=60131'],
+    11: ['韩国Melon排行榜周榜', '/discover/toplist?id=3733003'],
+    12: ['韩国Mnet排行榜周榜', '/discover/toplist?id=60255'],
+    13: ['韩国Melon原声周榜', '/discover/toplist?id=46772709'],
+    14: ['中国TOP排行榜(港台榜)', '/discover/toplist?id=112504'],
+    15: ['中国TOP排行榜(内地榜)', '/discover/toplist?id=64016'],
+    16: ['香港电台中文歌曲龙虎榜', '/discover/toplist?id=10169002'],
+    17: ['华语金曲榜', '/discover/toplist?id=4395559'],
+    18: ['中国嘻哈榜', '/discover/toplist?id=1899724'],
+    19: ['法国 NRJ EuroHot 30周榜', '/discover/toplist?id=27135204'],
+    20: ['台湾Hito排行榜', '/discover/toplist?id=112463'],
+    21: ['Beatport全球电子舞曲榜', '/discover/toplist?id=3812895']
+}
+
+default_timeout = 10
+
+modulus = ('00e0b509f6259df8642dbc35662901477df22677ec152b5ff68ace615bb7'
+           'b725152b3ab17a876aea8a5aa76d2e417629ec4ee341f56135fccf695280'
+           '104e0312ecbda92557c93870114af6c9d05c4f7f0c3685b7a46bee255932'
+           '575cce10b424d813cfe4875d3e82047b97ddef52741d546b8e289dc6935b'
+           '3ece0462db0a22b8e7')
+nonce = b'0CoJUm6Qyw8W8jud' ##因为AES加密，需编码为bytes
+pubKey = '010001'
+
+class Parse(object):
+    @classmethod
+    def _song_url_by_id(cls, sid):
+        # 128k
+        url = "http://music.163.com/song/media/outer/url?id={}.mp3".format(sid)
+        quality = "LD 128k"
+        return url, quality
+
+    @classmethod
+    def song_url(cls, song):
+        if "url" in song:
+            # songs_url resp
+            url = song["url"]
+            if url is None:
+                return Parse._song_url_by_id(song["id"])
+            br = song["br"]
+            if br >= 320000:
+                quality = "HD"
+            elif br >= 192000:
+                quality = "MD"
+            else:
+                quality = "LD"
+            return url, "{} {}k".format(quality, br // 1000)
+        else:
+            # songs_detail resp
+            return Parse._song_url_by_id(song["id"])
+
+    @classmethod
+    def song_album(cls, song):
+        # 对新老接口进行处理
+        if "al" in song:
+            if song["al"] is not None:
+                album_name = song["al"]["name"]
+                album_id = song["al"]["id"]
+            else:
+                album_name = "未知专辑"
+                album_id = ""
+        elif "album" in song:
+            if song["album"] is not None:
+                album_name = song["album"]["name"]
+                album_id = song["album"]["id"]
+            else:
+                album_name = "未知专辑"
+                album_id = ""
+        else:
+            raise ValueError
+        return album_name, album_id
+
+    @classmethod
+    def song_artist(cls, song):
+        artist = ""
+        # 对新老接口进行处理
+        if "ar" in song:
+            artist = ", ".join([a["name"] for a in song["ar"] if a["name"] is not None])
+            # 某些云盘的音乐会出现 'ar' 的 'name' 为 None 的情况
+            # 不过会多个 ’pc' 的字段
+            # {'name': '简单爱', 'id': 31393663, 'pst': 0, 't': 1, 'ar': [{'id': 0, 'name': None, 'tns': [], 'alias': []}],
+            #  'alia': [], 'pop': 0.0, 'st': 0, 'rt': None, 'fee': 0, 'v': 5, 'crbt': None, 'cf': None,
+            #  'al': {'id': 0, 'name': None, 'picUrl': None, 'tns': [], 'pic': 0}, 'dt': 273000, 'h': None, 'm': None,
+            #  'l': {'br': 193000, 'fid': 0, 'size': 6559659, 'vd': 0.0}, 'a': None, 'cd': None, 'no': 0, 'rtUrl': None,
+            #  'ftype': 0, 'rtUrls': [], 'djId': 0, 'copyright': 0, 's_id': 0, 'rtype': 0, 'rurl': None, 'mst': 9,
+            #  'cp': 0, 'mv': 0, 'publishTime': 0,
+            #  'pc': {'nickname': '', 'br': 192, 'fn': '简单爱.mp3', 'cid': '', 'uid': 41533322, 'alb': 'The One 演唱会',
+            #         'sn': '简单爱', 'version': 2, 'ar': '周杰伦'}, 'url': None, 'br': 0}
+            if artist == "" and "pc" in song:
+                artist = "未知艺术家" if song["pc"]["ar"] is None else song["pc"]["ar"]
+        elif "artists" in song:
+            artist = ", ".join([a["name"] for a in song["artists"]])
+        else:
+            artist = "未知艺术家"
+
+        return artist
+
+    @classmethod
+    def songs(cls, songs):
+        song_info_list = []
+        for song in songs:
+            url, quality = Parse.song_url(song)
+            if not url:
+                continue
+
+            album_name, album_id = Parse.song_album(song)
+            song_info = {
+                "song_id": song["id"],
+                "artist": Parse.song_artist(song),
+                "song_name": song["name"],
+                "album_name": album_name,
+                "album_id": album_id,
+                "mp3_url": url,
+                "quality": quality,
+                "expires": song["expires"],
+                "get_time": song["get_time"],
+            }
+            song_info_list.append(song_info)
+        return song_info_list
+
+    @classmethod
+    def artists(cls, artists):
+        return [
+            {
+                "artist_id": artist["id"],
+                "artists_name": artist["name"],
+                "alias": "".join(artist["alias"]),
+            }
+            for artist in artists
+        ]
+
+    @classmethod
+    def albums(cls, albums):
+        return [
+            {
+                "album_id": album["id"],
+                "albums_name": album["name"],
+                "artists_name": album["artist"]["name"],
+            }
+            for album in albums
+        ]
+
+    @classmethod
+    def playlists(cls, playlists):
+        return [
+            {
+                "playlist_id": pl["id"],
+                "playlist_name": pl["name"],
+                "creator_name": pl["creator"]["nickname"],
+            }
+            for pl in playlists
+        ]
+
+# 歌曲加密算法, 基于https://github.com/yanunon/NeteaseCloudMusic脚本实现
+def encrypted_id(id):
+    magic = bytearray('3go8&$8*3*3h0k(2)2', 'u8')
+    song_id = bytearray(id, 'u8')
+    magic_len = len(magic)
+    for i, sid in enumerate(song_id):
+        song_id[i] = sid ^ magic[i % magic_len]
+    m = hashlib.md5(song_id)
+    result = m.digest()
+    result = base64.b64encode(result)
+    result = result.replace(b'/', b'_')
+    result = result.replace(b'+', b'-')
+    return result.decode('utf-8')
+
+
+# 登录加密算法, 基于https://github.com/stkevintan/nw_musicbox脚本实现
+def encrypted_request(text):
+    text = json.dumps(text).encode('utf-8') ##因为pycryto很久没更新，所以需要编码成utf-8才行
+    log.debug(text)
+    secKey = createSecretKey(16)
+    encText = aesEncrypt(aesEncrypt(text, nonce), secKey)
+    encSecKey = rsaEncrypt(secKey, pubKey, modulus)
+    data = {'params': encText, 'encSecKey': encSecKey}
+    return data
+
+
+def aesEncrypt(text, secKey):
+    pad = 16 - len(text) % 16
+    text = text + bytearray([pad] * pad)
+    encryptor = AES.new(secKey, 2, b'0102030405060708')
+    ciphertext = encryptor.encrypt(text)
+    ciphertext = base64.b64encode(ciphertext)
+    return ciphertext
+
+
+def rsaEncrypt(text, pubKey, modulus):
+    text = text[::-1]
+    rs = pow(int(binascii.hexlify(text), 16), int(pubKey, 16), int(modulus, 16))
+    return format(rs, 'x').zfill(256)
+
+def createSecretKey(size):
+    return binascii.hexlify(os.urandom(size))[:16]
+
+# list去重
+def uniq(arr):
+    arr2 = list(set(arr))
+    arr2.sort(key=arr.index)
+    return arr2
+
+def geturl_new_api(song):
+    br_to_quality = {128000: 'MD 128k', 320000: 'HD 320k'}
+    alter = NetEase().songs_detail_new_api([song['id']])[0]
+    url = alter['url']
+    quality = br_to_quality.get(alter['br'], '')
+    return url, quality
+
+def geturls_new_api(song_ids):
+    """ 批量获取音乐的地址 """
+    alters = NetEase().songs_detail_new_api(song_ids)
+    return alters
+
+
+class NetEase(object):
+
+    def __init__(self):
+        self.header = {
+            'Accept': '*/*',
+            'Accept-Encoding': 'gzip,deflate,sdch',
+            'Accept-Language': 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Host': 'music.163.com',
+            'Referer': 'http://music.163.com/search/',
+            'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36'  # NOQA
+        }
+        self.cookies = {'appver': '1.5.2'}
+        self.playlist_class_dict = {}
+        self.session = requests.Session()
+        self.create_file(constants.getConfigData('cookies'))
+        self.create_file(constants.getConfigData('reqcache'))
+        requests_cache.install_cache(constants.getConfigData('reqcache'), expire_after=3600)
+        self.session.cookies = LWPCookieJar(constants.getConfigData('cookies'))
+        self.session.cookies.load()
+        for cookie in self.session.cookies:
+            if cookie.is_expired():
+                cookie_jar.clear()
+
+    def create_file(self, path, default="#LWP-Cookies-2.0\n"):
+        if not os.path.exists(path):
+            with open(path, "w") as f:
+                f.write(default)
+
+    def return_toplists(self):
+        return [l[0] for l in top_list_all.values()]
+
+    def httpRequest(self,
+                    method,
+                    action,
+                    query=None,
+                    urlencoded=None,
+                    callback=None,
+                    timeout=None):
+        connection = json.loads(
+            self.rawHttpRequest(method, action, query, urlencoded, callback, timeout)
+        )
+        return connection
+
+    def rawHttpRequest(self,
+                       method,
+                       action,
+                       query=None,
+                       urlencoded=None,
+                       callback=None,
+                       timeout=None):
+        if method == 'GET':
+            url = action if query is None else action + '?' + query
+            connection = self.session.get(url,
+                                          headers=self.header,
+                                          timeout=default_timeout)
+
+        elif method == 'POST':
+            connection = self.session.post(action,
+                                           data=query,
+                                           headers=self.header,
+                                           timeout=default_timeout)
+
+        elif method == 'Login_POST':
+            connection = self.session.post(action,
+                                           data=query,
+                                           headers=self.header,
+                                           timeout=default_timeout)
+            self.session.cookies.save()
+
+        connection.encoding = 'UTF-8'
+        return connection.text
+
+    def logout(self):
+            self.session.cookies.clear()
+            self.session.cookies.save()
+    # 登录
+    def login(self, username, password):
+        pattern = re.compile(r'^0\d{2,3}\d{7,8}$|^1[34578]\d{9}$')
+        if pattern.match(username):
+            return self.phone_login(username, password)
+        action = 'https://music.163.com/weapi/login?csrf_token='
+        text = {
+            'username': username,
+            'password': password,
+            'rememberLogin': 'true'
+        }
+        data = encrypted_request(text)
+        try:
+            return self.httpRequest('Login_POST', action, data)
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return {'code': 501}
+
+    # 手机登录
+    def phone_login(self, username, password):
+        action = 'https://music.163.com/weapi/login/cellphone'
+        text = {
+            'phone': username,
+            'password': password,
+            'rememberLogin': 'true'
+        }
+        data = encrypted_request(text)
+        try:
+            return self.httpRequest('Login_POST', action, data)
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return {'code': 501}
+
+    # 每日签到  --- 已修改 
+    def daily_signin(self, is_mobile):
+        action = 'http://music.163.com/weapi/point/dailyTask'
+        text = dict(type=0 if is_mobile else 1)
+        data = encrypted_request(text)
+        try:
+            return self.httpRequest('POST', action, data)
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # 用户歌单
+    def user_playlist(self, uid, offset=0, limit=100):
+        action = 'http://music.163.com/api/user/playlist/?offset={}&limit={}&uid={}'.format(  # NOQA
+            offset, limit, uid)
+        try:
+            data = self.httpRequest('GET', action)
+            return data['playlist']
+        except (requests.exceptions.RequestException, KeyError) as e:
+            log.error(e)
+            return -1
+
+    # like
+    def like_song(self, songid, like=True, time=25, alg='itembased'):
+        action = 'http://music.163.com/api/radio/like?alg={}&trackId={}&like={}&time={}'.format(  # NOQA
+            alg, songid, 'true' if like else 'false', time)
+
+        try:
+            data = self.httpRequest('GET', action)
+            return data["code"] == 200
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+   # 收藏歌单
+    def subscribe_playlist(self, playlist_id):
+        try:
+            action = 'http://music.163.com/weapi/playlist/subscribe'
+            data = dict(id=playlist_id, t=1)
+            self.session.cookies.load()
+            csrf = ''
+            for cookie in self.session.cookies:
+                if cookie.name == '__csrf':
+                    csrf = cookie.value
+            if csrf == '':
+                return False
+            data.update({"csrf_token": csrf})
+            page = self.session.post(action,
+                         data=encrypted_request(data),
+                         headers=self.header,
+                         timeout=default_timeout)
+            return json.loads(page.text)['code'] == 200
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # 每日推荐歌单 --- 和musicbox保持了一致
+    def recommend_resource(self):
+        try:
+            action = 'http://music.163.com/weapi/v1/discovery/recommend/resource?csrf_token='
+            self.session.cookies.load()
+            csrf = ''
+            for cookie in self.session.cookies:
+                if cookie.name == '__csrf':
+                    csrf = cookie.value
+            if csrf == '':
+                return False
+            action += csrf
+            req = {'csrf_token': csrf}
+            page = self.session.post(action,
+                         data=encrypted_request(req),
+                         headers=self.header,
+                         timeout=default_timeout)
+            return json.loads(page.text)['recommend']
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # 每日推荐歌单   --- 和musicbox保持了一致
+    def recommend_playlist(self):
+        try:
+            action = 'http://music.163.com/weapi/v1/discovery/recommend/songs?csrf_token='  # NOQA
+            self.session.cookies.load()
+            csrf = ''
+            for cookie in self.session.cookies:
+                if cookie.name == '__csrf':
+                    csrf = cookie.value
+            if csrf == '':
+                return False
+            action += csrf
+            req = {'offset': 0, 'total': True, 'limit': 20, 'csrf_token': csrf}
+            page = self.session.post(action,
+                                     data=encrypted_request(req),
+                                     headers=self.header,
+                                     timeout=default_timeout)
+            return json.loads(page.text)['recommend']
+        except (requests.exceptions.RequestException, ValueError) as e:
+            log.error(e)
+            return False
+
+    # 歌单详情
+    def playlist_detail(self, playlist_id):
+        try:
+            action = 'http://music.163.com/weapi/v3/playlist/detail'
+            data = dict(id=playlist_id, total="true", limit=1000, n=1000, offest=0)
+            self.session.cookies.load()
+            csrf = ''
+            for cookie in self.session.cookies:
+                if cookie.name == '__csrf':
+                    csrf = cookie.value
+            if csrf == '':
+                return False
+            data.update({"csrf_token": csrf})
+            page = self.session.post(action,
+                         data=encrypted_request(data),
+                         headers=self.header,
+                         timeout=default_timeout)
+            return json.loads(page.text)['playlist'].get("tracks", [])
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # 私人FM
+    def personal_fm(self):
+        action = 'http://music.163.com/api/radio/get'
+        try:
+            data = self.httpRequest('GET', action)
+            return data['data']
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # like
+    def fm_like(self, songid, like=True, time=25, alg='itembased'):
+        action = 'http://music.163.com/api/radio/like?alg={}&trackId={}&like={}&time={}'.format(  # NOQA
+            alg, songid, 'true' if like else 'false', time)
+
+        try:
+            data = self.httpRequest('GET', action)
+            if data['code'] == 200:
+                return data
+            else:
+                return -1
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # FM trash
+    def fm_trash(self, songid, time=25, alg='RT'):
+        action = 'http://music.163.com/api/radio/trash/add?alg={}&songId={}&time={}'.format(  # NOQA
+            alg, songid, time)
+        try:
+            data = self.httpRequest('GET', action)
+            if data['code'] == 200:
+                return data
+            else:
+                return -1
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return -1
+
+    # 搜索单曲(1)，歌手(100)，专辑(10)，歌单(1000)，用户(1002) *(type)*
+    def search(self, keywords, stype=1, offset=0, total='true', limit=60):
+        action = 'http://music.163.com/api/search/get'
+        data = dict(s=keywords, type=stype, offset=offset, total=total, limit=limit)
+        return self.httpRequest('POST', action, data).get("result", [])
+
+    # 歌手单曲
+    def artists(self, artist_id):
+        action = 'http://music.163.com/api/artist/{}'.format(artist_id)
+        try:
+            data = self.httpRequest('GET', action)
+            return data['hotSongs']
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return []
+
+    def get_artist_album(self, artist_id, offset=0, limit=50):
+        action = 'http://music.163.com/api/artist/albums/{}?offset={}&limit={}'.format(
+            artist_id, offset, limit)
+        try:
+            data = self.httpRequest('GET', action)
+            return data['hotAlbums']
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return []
+
+    # album id --> song id set
+    def album(self, album_id):
+        action = 'http://music.163.com/api/album/{}'.format(album_id)
+        try:
+            data = self.httpRequest('GET', action)
+            return data['album']['songs']
+        except requests.exceptions.RequestException as e:
+            log.error(e)
+            return []
+
+    def songs_detail_new_api(self, music_ids, bit_rate=320000):
+        action = 'http://music.163.com/weapi/song/enhance/player/url?csrf_token='  # NOQA
+        self.session.cookies.load()
+        csrf = ''
+        for cookie in self.session.cookies:
+            if cookie.name == '__csrf':
+                csrf = cookie.value
+        if csrf == '':
+            notify('You Need Login', 1)
+        action += csrf
+        data = {'ids': music_ids, 'br': bit_rate, 'csrf_token': csrf}
+        connection = self.session.post(action,
+                                       data=encrypted_request(data),
+                                       headers=self.header, )
+        result = json.loads(connection.text)
+        return result['data']
+    
+    def dig_info(self, data, dig_type):
+        temp = []
+        if not data:
+            return []
+        if dig_type == 'songs' or dig_type == 'fmsongs':
+            urls = geturls_new_api([s["id"] for s in data])
+            timestamp = time.time()
+            # api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致
+            # 为了获取到对应 id 的 url，对返回的 urls 做一个 id2index 的缓存
+            # 同时保证 data 的 id 顺序不变
+            url_id_index = {}
+            for index, url in enumerate(urls):
+                url_id_index[url["id"]] = index
+            for s in data:
+                url_index = url_id_index.get(s["id"])
+                if url_index is None:
+                    log.error("can't get song url, id: %s", s["id"])
+                    continue
+                s["url"] = urls[url_index]["url"]
+                s["br"] = urls[url_index]["br"]
+                s["expires"] = urls[url_index]["expi"]
+                s["get_time"] = timestamp
+            temp = Parse.songs(data)
+
+        elif dig_type == 'artists':
+            artists = []
+            for i in range(0, len(data)):
+                artists_info = {
+                    'artist_id': data[i]['id'],
+                    'artists_name': data[i]['name'],
+                    'alias': ''.join(data[i]['alias'])
+                }
+                artists.append(artists_info)
+            return artists
+
+        elif dig_type == 'albums':
+            for i in range(0, len(data)):
+                albums_info = {
+                    'album_id': data[i]['id'],
+                    'albums_name': data[i]['name'],
+                    'artists_name': data[i]['artist']['name']
+                }
+                temp.append(albums_info)
+
+        elif dig_type == 'top_playlists':
+            temp = Parse.playlists(data)
+
+        elif dig_type == 'playlist_class_detail':
+            log.debug(data)
+            temp = self.playlist_class_dict[data]
+        return temp

--- a/sdk/NetEaseApi.py
+++ b/sdk/NetEaseApi.py
@@ -5,12 +5,9 @@
 '''
 网易云音乐 Api
 '''
-from builtins import chr
 from builtins import int
-from builtins import map
 from builtins import open
 from builtins import range
-from builtins import str
 from builtins import pow
 
 import re
@@ -18,10 +15,8 @@ import os
 import json
 import time
 import hashlib
-import random
 import base64
 import binascii
-import sys
 
 from Crypto.Cipher import AES
 from http.cookiejar import LWPCookieJar
@@ -285,7 +280,7 @@ class NetEase(object):
         self.session.cookies.load()
         for cookie in self.session.cookies:
             if cookie.is_expired():
-                cookie_jar.clear()
+                self.session.cookies.clear()
 
     def create_file(self, path, default="#LWP-Cookies-2.0\n"):
         if not os.path.exists(path):
@@ -373,7 +368,7 @@ class NetEase(object):
             return {'code': 501}
 
     # 每日签到  --- 已修改 
-    def daily_signin(self, is_mobile):
+    def daily_task(self, is_mobile):
         action = 'http://music.163.com/weapi/point/dailyTask'
         text = dict(type=0 if is_mobile else 1)
         data = encrypted_request(text)
@@ -577,7 +572,7 @@ class NetEase(object):
             if cookie.name == '__csrf':
                 csrf = cookie.value
         if csrf == '':
-            notify('You Need Login', 1)
+            log.error('You Need Login', 1)
         action += csrf
         data = {'ids': music_ids, 'br': bit_rate, 'csrf_token': csrf}
         connection = self.session.post(action,


### PR DESCRIPTION
## WangYiYun ##

* 根据Github上的[musicbox](https://github.com/darknessomi/musicbox)所提供的api文件进行抽离和修改，当中也要感谢wzpan大佬之前写的[API](https://github.com/wzpan/MusicBoxApi)。
* 目前主要围绕**每日推荐歌单**，**每日推荐歌曲**和**我的歌单**功能进行开发，其中还包括**自动签到**，**询问当前播放歌曲信息**和**基本播放器功**能，往后还会有更多功能请敬请期待一下。
* 花费的时间较多在if-else的逻辑判断，也就是插件的handle方法，欢迎大家多出建议和问题来改良（代码稍微有些欠缺）。
* 源码：[https://github.com/wzpan/wukong-contrib/blob/HEAD/BaiduMap.py](https://github.com/wzpan/wukong-contrib/blob/HEAD/WangYiYun.py)

### 配置
1. 首先请将账号信息配置在config.yml，如以下的方式配置。
``` yml
# 网易云音乐插件
WangYiYun:
    account: 'XXXXXXXX'  # 网易云音乐账号
    #密码的 md5，可以用 python3 wukong.py md5 "密码" 获得
    md5pass: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx' 
```
2. 将~/.wukong/contrib主库更新一下以获取WangYiYun.py插件，还有需要下载一些额外的第三方库。
``` sh
git pull
pip3 install -r requirements.txt
``` 

### 关于首次登陆的那些事
* 首次登陆会通过账号信息尝试获取两周有效期的Cookies并保存于本地~/.wukong/，同时会定期检查有效期。
* ~/.wukong/文件有一个名为reqcache文件，用于requests的缓存。
* 首次登陆后会在config.yml写入userid和nickname，便于往后的查询请求。


### 交互示例
> 为了简化交互和满足不同的问句，一次的播报信息中只会包含五个歌单名称，可以对悟空喊：“我想听下去”来了解更多歌单名称。

---> 每日推荐歌单 / 我的歌单
- 用户：打开网易云的推荐歌单 / 打开我的网易云歌单
- 悟空：共找到X张歌单，第1张叫XXX，第2张叫XXX...想听哪一张，或者要不要继续听下去呢？
- 用户：我想听下去 / 我要继续听更多
- 悟空：共找到X张歌单，第6张叫XXX，第7张叫XXX...想听哪一张，或者要不要继续听下去呢？
- 用户：刚刚第4张歌单叫什么来的
- 悟空：第四张歌单叫XXXX
- 用户：那我要听第4张
- 悟空：选了第4张

---> 每日推荐歌曲
- 用户：打开网易云的推荐歌曲
- 悟空：一共有X首推荐歌曲噢！（然后播放歌曲）

---> 播放歌曲时的语句：
- 用户：这首歌叫什么
- 悟空：这首歌叫XXX，是XXX唱的
- 用户：这张歌单叫什么名字
- 悟空：目前播放的歌单叫XXX
- 用户：我想要收藏这首歌  / 我要收藏这个歌单
- 悟空：这首歌已帮你收藏成功 / 目前的歌单已收藏成功！
- 用户：再放一遍吧
- 悟空：重新播放当前的歌曲