### PR TITLE
[fix] 网易云音乐插件优化点歌逻辑

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ paho-mqtt>=1.3.0
 eyeD3>=0.8
 requests_cache==0.5.2
 jsonpath==0.82
-
+pycryptodome==3.9.7


### PR DESCRIPTION
优化判断逻辑（由于不能很好的拆分歌手名和歌曲名）
            # 例：播放许飞的父亲写的散文诗
            #       singerName: 许飞的父亲写
            #       songName: 散文诗